### PR TITLE
ffda-domain-director: make /etc/config/ffda available on initial setup

### DIFF
--- a/ffda-domain-director/Makefile
+++ b/ffda-domain-director/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ffda-domain-director
 PKG_VERSION:=2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(TOPDIR)/../package/gluon.mk
 

--- a/ffda-domain-director/files/etc/config/ffda
+++ b/ffda-domain-director/files/etc/config/ffda
@@ -1,0 +1,2 @@
+config director 'director'
+	option enabled '1'

--- a/ffda-domain-director/luasrc/lib/gluon/upgrade/950-ffda-domain-director
+++ b/ffda-domain-director/luasrc/lib/gluon/upgrade/950-ffda-domain-director
@@ -7,11 +7,6 @@ local unistd = require 'posix.unistd'
 
 local ddutil = require 'ffda-domain-director.util'
 
--- Create UCI configuration file if not present
-local touch_handle = io.popen("touch /etc/config/ffda")
-touch_handle:read('*all')
-touch_handle:close()
-
 -- Create UCI section
 local director_enabled = true
 if uci:get("ffda", "director", "enabled") ~= nil then


### PR DESCRIPTION
Currently it is not possible to disable the domain-director package during initial setup as _/etc/config/ffda_ doesn't exist at this point. A user might think he/she disabled it but didn't. An other problem with the current version is that the "Enabled" checkbox is unchecked by default and so a user could think this feature is opt-in and not opt-out.

Tested initial setup and sysupgrade.